### PR TITLE
Add JCK certified flag to AO8/OpenJ9 Linux/PPCLE and Linux/s390x

### DIFF
--- a/jck.json
+++ b/jck.json
@@ -1,5 +1,11 @@
 {
   "jdk8u162-b12_openj9-0.8.0": {
     "X64_LINUX": "true"
+  },
+  "jdk8u162-b12_openj9-0.8.0": {
+    "PPC64LE_LINUX": "true"
+  },
+  "jdk8u162-b12_openj9-0.8.0": {
+    "S390X_LINUX": "true"
   }
 }

--- a/jck.json
+++ b/jck.json
@@ -1,11 +1,7 @@
 {
   "jdk8u162-b12_openj9-0.8.0": {
-    "X64_LINUX": "true"
-  },
-  "jdk8u162-b12_openj9-0.8.0": {
-    "PPC64LE_LINUX": "true"
-  },
-  "jdk8u162-b12_openj9-0.8.0": {
+    "X64_LINUX": "true",
+    "PPC64LE_LINUX": "true",
     "S390X_LINUX": "true"
   }
 }


### PR DESCRIPTION
@gdams Can you check I've done this right with the names etc.? I presume this is enough to get the flags on the other two architectures?